### PR TITLE
Styling improvements for Craft 4.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-This plugin requires Craft CMS 3.1.0 or later.
+This plugin requires Craft CMS 4.9.0 or later.
 
 A version compatible with Craft 3.0.0 can be found [here](https://github.com/studioespresso/craft3-navigate/tree/Craft_3.0.x)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0-RC1"
+        "craftcms/cms": "^4.9.0"
     },
     "require-dev": {
         "craftcms/ecs": "dev-main",

--- a/src/assetbundles/Navigate/dist/css/Navigate.css
+++ b/src/assetbundles/Navigate/dist/css/Navigate.css
@@ -21,13 +21,11 @@ body.ltr .structure ul {
     margin-left: 0px;
 }
 body.ltr .structure ul li {
-    background-position: 9px 2px;
+    --background-position-x: 9px;
     padding-left: 47px;
 }
 
 body.ltr .structure ul li:not(:last-child):not(.last) {
-    padding-left: 36px;
-    border-left: 1px solid #e3e5e8;
     margin-left: 9px;
 }
 


### PR DESCRIPTION
Improves the tree styling, and fixes a minor styling issue that will be introduced in Craft 4.9 due to https://github.com/craftcms/cms/commit/467f295397696b6111bd07d0dcb7942bbd572fe2.

Note that the change takes advantage of a new `--background-position-x` CSS variable that is coming in 4.9 via that commit.

**Before - Craft 4.8:** (note the minor border color difference)

![A tree structure before this PR, on Craft 4.8](https://github.com/studioespresso/craft-navigate/assets/47792/aabda9a8-6483-406f-a73e-d004ca64340f)

**Before - Craft 4.9:**

![A tree structure before this PR, on Craft 4.9](https://github.com/studioespresso/craft-navigate/assets/47792/b38856de-4024-40a1-8b82-246e5b4da44d)

**After - Craft 4.9:**

![A tree structure with this PR, on Craft 4.9](https://github.com/studioespresso/craft-navigate/assets/47792/de9e78ec-8709-4096-98bf-1789c7a1d65c)

